### PR TITLE
#13 - waypoints only

### DIFF
--- a/simulation_ws/src/rl-agent/markov/environments/mars_env.py
+++ b/simulation_ws/src/rl-agent/markov/environments/mars_env.py
@@ -478,9 +478,9 @@ class MarsEnv(gym.Env):
             
 
             # No Episode ending events - continue to calculate reward - general waypoints not helpful
-           """ # smooth reward with no waypoints
+            # smooth reward with no waypoints
             multiplier = 1 - (self.current_distance_to_checkpoint/INITIAL_DISTANCE_TO_CHECKPOINT)**4
-            """
+            
             """
             progress = INITIAL_DISTANCE_TO_CHECKPOINT / self.current_distance_to_checkpoint
             


### PR DESCRIPTION
What I've done here is remove the smooth reward function that @wakeuplearn added. This was supposed to be able to do the same thing as the waypoints in the reward function, but without the waypoints. Edwin's added waypoints and this smooth function, so I've highlighted this in #13 as well as this PR